### PR TITLE
refactor: share _collect_matrix util

### DIFF
--- a/tools/clustering.py
+++ b/tools/clustering.py
@@ -36,6 +36,7 @@ import pandas as pd
 from sklearn.neighbors import LocalOutlierFactor
 from sklearn.metrics import silhouette_score, pairwise_distances
 from sklearn.mixture import GaussianMixture
+from .matrix_utils import _collect_matrix
 
 # --- HDBSCAN ---
 try:
@@ -221,22 +222,6 @@ def distance_to_medoid(Z: np.ndarray, labels: np.ndarray) -> np.ndarray:
 # ======================================================
 # --------------- ПРОТОТИПЫ КЛАСТЕРОВ ------------------
 # ======================================================
-
-def _collect_matrix(panel_long: pd.DataFrame, wells: Sequence[str], channel: str, T: int) -> np.ndarray:
-    """Собирает матрицу [n_series, T] по указанному каналу с NaN.
-    """
-    rows = []
-    for w in wells:
-        g = panel_long.loc[panel_long["well_name"] == w, ["t", channel]].sort_values("t")
-        v = np.full(T, np.nan, float)
-        t = g["t"].to_numpy(int)
-        vals = g[channel].to_numpy(float)
-        t = t[(t >= 0) & (t < T)]
-        vals = vals[: len(t)]
-        v[t[: len(vals)]] = vals
-        rows.append(v)
-    return np.vstack(rows) if rows else np.empty((0, T))
-
 
 def _barycenter_or_median(M: np.ndarray, method: str = "auto", gamma: float = 1.0, max_iter: int = 50) -> np.ndarray:
     """Возвращает барицентр (soft-DTW/DBA) или медиану по времени, если tslearn недоступен.

--- a/tools/make_reports.py
+++ b/tools/make_reports.py
@@ -36,6 +36,7 @@ import pandas as pd
 import matplotlib
 matplotlib.use("Agg")  # рендер без GUI
 import matplotlib.pyplot as plt
+from .matrix_utils import _collect_matrix
 
 try:
     from tqdm import tqdm
@@ -47,20 +48,6 @@ except Exception:
 
 def _ensure_dir(path: str) -> None:
     os.makedirs(path, exist_ok=True)
-
-
-def _collect_matrix(panel_long: pd.DataFrame, wells: Sequence[str], channel: str, T: int) -> np.ndarray:
-    rows = []
-    for w in wells:
-        g = panel_long.loc[panel_long["well_name"] == w, ["t", channel]].sort_values("t")
-        v = np.full(T, np.nan, float)
-        t = g["t"].to_numpy(int)
-        vals = g[channel].to_numpy(float)
-        t = t[(t >= 0) & (t < T)]
-        vals = vals[: len(t)]
-        v[t[: len(vals)]] = vals
-        rows.append(v)
-    return np.vstack(rows) if rows else np.empty((0, T))
 
 
 # ----------------------- КАРТА PBM ------------------------

--- a/tools/matrix_utils.py
+++ b/tools/matrix_utils.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+
+
+def _collect_matrix(panel_long: pd.DataFrame, wells: Sequence[str], channel: str, T: int) -> np.ndarray:
+    """Собирает матрицу [n_series, T] по указанному каналу с NaN."""
+    rows = []
+    for w in wells:
+        g = panel_long.loc[panel_long["well_name"] == w, ["t", channel]].sort_values("t")
+        v = np.full(T, np.nan, float)
+        t = g["t"].to_numpy(int)
+        vals = g[channel].to_numpy(float)
+        t = t[(t >= 0) & (t < T)]
+        vals = vals[: len(t)]
+        v[t[: len(vals)]] = vals
+        rows.append(v)
+    return np.vstack(rows) if rows else np.empty((0, T))


### PR DESCRIPTION
## Summary
- extract shared `_collect_matrix` helper into `matrix_utils`
- reuse `_collect_matrix` in `clustering` and `make_reports` modules

## Testing
- `pytest`
- `pip install numpy` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c80c6c8f9c832e8eaf4d21178f335e