### PR TITLE
Remove unused RobustScaler import from manifold module

### DIFF
--- a/tools/manifold.py
+++ b/tools/manifold.py
@@ -36,7 +36,6 @@ except Exception:
 
 
 # sklearn
-from sklearn.preprocessing import RobustScaler
 from sklearn.neighbors import NearestNeighbors
 from sklearn.metrics import pairwise_distances
 


### PR DESCRIPTION
## Summary
- drop unused `RobustScaler` import from the manifold module
- verify no other files depend on that import

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c80c7cdfe0832e9fe89b0838d9fcfc