### PR TITLE
Remove local NumPy import in forecast evaluation

### DIFF
--- a/tools/forecast.py
+++ b/tools/forecast.py
@@ -171,7 +171,6 @@ def multioutput_forecast(panel_long: pd.DataFrame, wells:list, T:int, T_pref:int
 
 def evaluate_forecasts(Y_true, Y_pred):
     """RMSE и sMAPE по строкам, где и факт, и прогноз без NaN; без зависимости от 'squared'."""
-    import numpy as np
     mask = np.isfinite(Y_pred).all(axis=1) & np.isfinite(Y_true).all(axis=1)
     n_eval = int(mask.sum())
     if n_eval == 0:


### PR DESCRIPTION
## Summary
- Use module-level NumPy import instead of a per-function import in `evaluate_forecasts`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c80c83c0c0832e8ae00fd4e1cfe5f1