### PR TITLE
Optimize collect matrix grouping

### DIFF
--- a/tools/matrix_utils.py
+++ b/tools/matrix_utils.py
@@ -9,13 +9,19 @@ import pandas as pd
 def _collect_matrix(panel_long: pd.DataFrame, wells: Sequence[str], channel: str, T: int) -> np.ndarray:
     """Собирает матрицу [n_series, T] по указанному каналу с NaN."""
     rows = []
+    groups = panel_long.groupby("well_name")
     for w in wells:
-        g = panel_long.loc[panel_long["well_name"] == w, ["t", channel]].sort_values("t")
+        g = (
+            groups.get_group(w)[["t", channel]].sort_values("t")
+            if w in groups.groups
+            else pd.DataFrame(columns=["t", channel])
+        )
         v = np.full(T, np.nan, float)
         t = g["t"].to_numpy(int)
         vals = g[channel].to_numpy(float)
-        t = t[(t >= 0) & (t < T)]
-        vals = vals[: len(t)]
-        v[t[: len(vals)]] = vals
+        mask = (t >= 0) & (t < T)
+        t = t[mask]
+        vals = vals[mask]
+        v[t] = vals  # Предполагается, что t отсортирован по возрастанию
         rows.append(v)
     return np.vstack(rows) if rows else np.empty((0, T))


### PR DESCRIPTION
## Summary
- group panel data by well name once and reuse groups in `_collect_matrix`
- filter time values with a boolean mask and remove length-based slicing
- document assumption that time values are sorted

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c80fdcafac832ea448ce2f23cd8fa9