### PR TITLE
Avoid unnecessary distances in manifold neighbor search

### DIFF
--- a/tools/manifold.py
+++ b/tools/manifold.py
@@ -167,7 +167,7 @@ def embed_umap_fastdtw(
         k = cfg.k_refine if candidate_knn is None else candidate_knn
         nn = NearestNeighbors(n_neighbors=min(k+1, Ns), metric="euclidean")
         nn.fit(Xflat)
-        dists, inds = nn.kneighbors(Xflat, return_distance=True)
+        inds = nn.kneighbors(Xflat, return_distance=False)
         # inds[:,0] — сама точка; начнём с 1..
         pairs = set()
         for i in range(Ns):


### PR DESCRIPTION
## Summary
- Only request neighbor indices from `NearestNeighbors.kneighbors`

## Testing
- `python -m py_compile tools/manifold.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c80f68d12c832ea6efd82d7f77ade5