### PR TITLE
Clarify embed_umap_fastdtw return value

### DIFF
--- a/tools/manifold.py
+++ b/tools/manifold.py
@@ -121,7 +121,7 @@ def embed_umap_fastdtw(
     cfg: Optional[ManifoldConfig] = None,
     sample_size: Optional[int] = None,
     candidate_knn: Optional[int] = None,
-) -> Tuple[np.ndarray, List[str], np.ndarray, Dict[str, object]]:
+) -> Tuple[np.ndarray, List[int], np.ndarray, Dict[str, object]]:
     """UMAP с уточнением FastDTW для ближайших пар.
 
     Алгоритм:
@@ -132,7 +132,9 @@ def embed_umap_fastdtw(
 
     Если sample_size задан, берём случайную подвыборку для ускорения.
 
-    Возвращает: (Z, wells_sub, D, info)
+    Возвращает: (Z, sub_idx, D, info)
+        sub_idx — индексы элементов исходного массива ``X``,
+        попавшие в подвыборку (list[int]).
     """
     if cfg is None:
         cfg = ManifoldConfig()


### PR DESCRIPTION
## Summary
- document that embed_umap_fastdtw returns indices (`sub_idx`) rather than well names
- fix return type annotation to `List[int]`

## Testing
- `python -m py_compile tools/manifold.py`


------
https://chatgpt.com/codex/tasks/task_e_68c810222b00832ea27a914d7be8f888