### PR TITLE
Add cluster voting forecast pipeline notebook

### DIFF
--- a/notebooks/cluster_prefix_forecast.ipynb
+++ b/notebooks/cluster_prefix_forecast.ipynb
@@ -1,0 +1,486 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# PBM: кластеризация на эталоне и прогноз по префиксу\n",
+        "\n",
+        "Этот ноутбук строит карту поведения и кластеры на эталонной выборке скважин, а затем относит новые скважины к кластерам и прогнозирует хвост профиля только по соседям выбранного кластера."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "import glob\n",
+        "import json\n",
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "from tools.preprocessing import preprocess_profiles, PreprocConfig\n",
+        "from tools.manifold import embed_umap_euclid, ManifoldConfig\n",
+        "from tools.clustering import cluster_hdbscan, ClusterConfig\n",
+        "from tools.forecast import (\n",
+        "    build_prefix_scaled_channel,\n",
+        "    make_matrices,\n",
+        "    vote_cluster_by_prefix,\n",
+        "    knn_forecast,\n",
+        "    evaluate_forecasts,\n",
+        ")\n",
+        "\n",
+        "pd.set_option(\"display.max_rows\", 20)\n",
+        "pd.set_option(\"display.max_columns\", 40)\n",
+        "plt.style.use(\"seaborn-v0_8\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Шаг 0. Конфигурация входных данных и параметров"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "data_folder = \"data/wells\"\n",
+        "\n",
+        "# если нужно зафиксировать конкретный список скважин для прогноза — укажите здесь\n",
+        "forecast_wells_manual = []  # например: [\"WELL_001\", \"WELL_002\"]\n",
+        "holdout_fraction = 0.10  # если список пуст — доля скважин для прогноза выбирается случайно\n",
+        "\n",
+        "T_total = 100  # горизонт после предобработки\n",
+        "T_pref = 20    # длина префикса для прогноза\n",
+        "\n",
+        "umap_cfg = ManifoldConfig(n_neighbors=30, min_dist=0.05, n_components=2, random_state=43)\n",
+        "cluster_cfg = ClusterConfig(min_cluster_size=50, min_samples=12)\n",
+        "K_vote = 7      # число соседей для голосования кластеров по префиксу\n",
+        "K_forecast = 15  # число соседей для прогноза хвоста\n",
+        "\n",
+        "rng = np.random.default_rng(42)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Шаг 1. Загрузка и первичная очистка данных"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "all_csv = sorted(glob.glob(os.path.join(data_folder, \"*.csv\")))\n",
+        "if not all_csv:\n",
+        "    raise FileNotFoundError(f\"В папке {data_folder!r} не найдено CSV-файлов.\")\n",
+        "\n",
+        "# объединяем данные из всех файлов\n",
+        "df_raw = pd.concat((pd.read_csv(path) for path in all_csv), ignore_index=True)\n",
+        "df_raw = df_raw.sort_values([\"well_name\", \"date\"]).reset_index(drop=True)\n",
+        "\n",
+        "# отбрасываем заведомо не добывающие записи\n",
+        "df_raw = df_raw[(df_raw[\"oil\"] >= 0) & (df_raw[\"gas\"] >= 0) & (df_raw[\"water\"] >= 0)]\n",
+        "print(f\"Raw dataframe shape: {df_raw.shape}\")\n",
+        "df_raw.head()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Шаг 1а. Предобработка профилей"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "preproc_cfg = PreprocConfig(T=T_total)\n",
+        "out = preprocess_profiles(df_raw, preproc_cfg)\n",
+        "\n",
+        "panel_long = out[\"panel_long\"]\n",
+        "X_tensor = out[\"X\"]\n",
+        "wells_used = out[\"wells_used\"]\n",
+        "tensor_channels = out[\"tensor_channels\"]\n",
+        "T_total = int(out[\"config\"][\"T\"])\n",
+        "\n",
+        "print(f\"Всего скважин после фильтрации: {len(wells_used)}\")\n",
+        "panel_long.head()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Шаг 2. Деление на эталонную и прогнозную выборки"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "if forecast_wells_manual:\n",
+        "    forecast_wells = sorted(set(forecast_wells_manual))\n",
+        "else:\n",
+        "    n_forecast = max(1, int(len(wells_used) * holdout_fraction))\n",
+        "    forecast_wells = sorted(rng.choice(wells_used, size=n_forecast, replace=False))\n",
+        "\n",
+        "reference_wells = [w for w in wells_used if w not in forecast_wells]\n",
+        "\n",
+        "print(f\"Reference wells: {len(reference_wells)}\")\n",
+        "print(f\"Forecast wells: {len(forecast_wells)}\")\n",
+        "if len(reference_wells) < 10:\n",
+        "    print(\"Предупреждение: очень мало эталонных скважин — проверьте параметры выборки.\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Шаг 3. Manifold UMAP на эталонных скважинах"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "ref_indices = np.array([i for i, w in enumerate(wells_used) if w in reference_wells])\n",
+        "if ref_indices.size == 0:\n",
+        "    raise ValueError(\"Нет эталонных скважин для построения manifold.\")\n",
+        "\n",
+        "X_ref = X_tensor[ref_indices]\n",
+        "\n",
+        "Z_ref, umap_model = embed_umap_euclid(\n",
+        "    X_ref,\n",
+        "    tensor_channels,\n",
+        "    channels=umap_cfg.channels,\n",
+        "    n_neighbors=umap_cfg.n_neighbors,\n",
+        "    min_dist=umap_cfg.min_dist,\n",
+        "    n_components=umap_cfg.n_components,\n",
+        "    random_state=umap_cfg.random_state,\n",
+        ")\n",
+        "\n",
+        "wells_ref = [wells_used[i] for i in ref_indices]\n",
+        "df_umap = pd.DataFrame({\"well_name\": wells_ref, \"x\": Z_ref[:, 0], \"y\": Z_ref[:, 1]})\n",
+        "df_umap.head()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "plt.figure(figsize=(6, 5))\n",
+        "plt.scatter(df_umap[\"x\"], df_umap[\"y\"], s=20, alpha=0.7)\n",
+        "plt.title(\"UMAP на эталонной выборке\")\n",
+        "plt.xlabel(\"UMAP-1\")\n",
+        "plt.ylabel(\"UMAP-2\")\n",
+        "plt.grid(True, alpha=0.2)\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Шаг 4. Кластеризация HDBSCAN"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "cluster_res = cluster_hdbscan(Z_ref, wells_ref, cfg=cluster_cfg)\n",
+        "df_map = cluster_res[\"df_map\"]\n",
+        "print(\n",
+        "    f\"Silhouette={cluster_res['silhouette']:.3f}, DBCV={cluster_res['dbcv']:.3f}\"\n",
+        ")\n",
+        "df_map.head()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "cluster_counts = (\n",
+        "    df_map.groupby(\"cluster\").size().rename(\"count\").reset_index().sort_values(\"count\", ascending=False)\n",
+        ")\n",
+        "cluster_counts.head()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Шаг 5. Префикс-канал и матрицы для прогноза"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "panel_long_pref = build_prefix_scaled_channel(\n",
+        "    panel_long,\n",
+        "    wells_used,\n",
+        "    T=T_total,\n",
+        "    T_pref=T_pref,\n",
+        "    rate_col=\"r_oil_s\",\n",
+        "    out_col=\"r_oil_pref_norm\",\n",
+        ")\n",
+        "\n",
+        "X_pref, Y_suffix_true, Y_full = make_matrices(\n",
+        "    panel_long_pref,\n",
+        "    wells_used,\n",
+        "    T=T_total,\n",
+        "    T_pref=T_pref,\n",
+        "    channel=\"r_oil_pref_norm\",\n",
+        "    target_col=\"r_oil_s\",\n",
+        ")\n",
+        "\n",
+        "print(f\"X_pref shape: {X_pref.shape}, Y_full shape: {Y_full.shape}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Шаг 6. Отнесение новых скважин к кластерам по префиксу"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "forecast_indices = [i for i, w in enumerate(wells_used) if w in forecast_wells]\n",
+        "\n",
+        "vote_df, vote_details = vote_cluster_by_prefix(\n",
+        "    X_pref,\n",
+        "    wells_used,\n",
+        "    df_map,\n",
+        "    target_indices=forecast_indices,\n",
+        "    K_vote=K_vote,\n",
+        "    allow_noise=True,\n",
+        ")\n",
+        "vote_df"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "cluster_summary = pd.DataFrame({\"well_name\": wells_used})\n",
+        "cluster_summary[\"role\"] = np.where(\n",
+        "    cluster_summary[\"well_name\"].isin(reference_wells), \"reference\", \"forecast\"\n",
+        ")\n",
+        "cluster_summary = cluster_summary.merge(\n",
+        "    df_map[[\"well_name\", \"cluster\", \"prob\"]].rename(\n",
+        "        columns={\"cluster\": \"cluster_ref\", \"prob\": \"cluster_prob\"}\n",
+        "    ),\n",
+        "    on=\"well_name\",\n",
+        "    how=\"left\",\n",
+        ")\n",
+        "cluster_summary = cluster_summary.merge(\n",
+        "    vote_df.rename(columns={\"cluster_vote\": \"cluster_vote\", \"vote_conf\": \"vote_conf\"}),\n",
+        "    on=\"well_name\",\n",
+        "    how=\"left\",\n",
+        ")\n",
+        "cluster_summary[\"cluster_ref\"] = pd.to_numeric(\n",
+        "    cluster_summary[\"cluster_ref\"], errors=\"coerce\"\n",
+        ").astype(\"Int64\")\n",
+        "cluster_summary[\"cluster_vote\"] = pd.to_numeric(\n",
+        "    cluster_summary[\"cluster_vote\"], errors=\"coerce\"\n",
+        ").astype(\"Int64\")\n",
+        "cluster_summary[\"cluster_final\"] = cluster_summary.apply(\n",
+        "    lambda row: row[\"cluster_ref\"] if row[\"role\"] == \"reference\" else row[\"cluster_vote\"],\n",
+        "    axis=1,\n",
+        ")\n",
+        "cluster_summary[\"cluster_final\"] = pd.to_numeric(\n",
+        "    cluster_summary[\"cluster_final\"], errors=\"coerce\"\n",
+        ").astype(\"Int64\")\n",
+        "cluster_summary[\"confidence\"] = cluster_summary.apply(\n",
+        "    lambda row: row[\"cluster_prob\"] if row[\"role\"] == \"reference\" else row[\"vote_conf\"],\n",
+        "    axis=1,\n",
+        ")\n",
+        "cluster_summary.head()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "cluster_summary.groupby([\"role\", \"cluster_final\"], dropna=False).size()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Шаг 7. Пулы соседей по кластерам"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "mask_full = np.isfinite(Y_full).sum(axis=1) >= Y_full.shape[1]\n",
+        "train_idx = np.where(mask_full)[0]\n",
+        "\n",
+        "cluster_to_train = {}\n",
+        "for idx in train_idx:\n",
+        "    cluster_val = cluster_summary.loc[idx, \"cluster_final\"]\n",
+        "    if pd.notna(cluster_val):\n",
+        "        cluster_to_train.setdefault(int(cluster_val), []).append(int(idx))\n",
+        "\n",
+        "candidate_pools = {}\n",
+        "for idx, cluster_val in cluster_summary[\"cluster_final\"].items():\n",
+        "    if pd.isna(cluster_val):\n",
+        "        continue\n",
+        "    pool = cluster_to_train.get(int(cluster_val), [])\n",
+        "    if pool:\n",
+        "        candidate_pools[int(idx)] = pool\n",
+        "\n",
+        "print(f\"Всего тренировочных скважин с полным горизонтом: {len(train_idx)}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Шаг 8. Прогноз хвоста по соседям выбранного кластера"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "target_indices = sorted(set(train_idx.tolist()) | set(forecast_indices))\n",
+        "\n",
+        "Y_pred_knn, knn_info = knn_forecast(\n",
+        "    X_pref,\n",
+        "    Y_full,\n",
+        "    T_pref=T_pref,\n",
+        "    K=K_forecast,\n",
+        "    target_indices=target_indices,\n",
+        "    candidate_pools=candidate_pools,\n",
+        ")\n",
+        "\n",
+        "metrics_knn = evaluate_forecasts(Y_suffix_true, Y_pred_knn)\n",
+        "print(\"KNN metrics:\")\n",
+        "print(json.dumps(metrics_knn, indent=2, ensure_ascii=False))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Шаг 9. Просмотр прогнозов для новых скважин"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "suffix_cols = [f\"m{t}\" for t in range(T_pref + 1, T_total + 1)]\n",
+        "forecast_table = pd.DataFrame(Y_pred_knn[forecast_indices], columns=suffix_cols)\n",
+        "forecast_table.insert(0, \"well_name\", [wells_used[i] for i in forecast_indices])\n",
+        "forecast_table.head()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "def plot_forecast(well_name: str):\n",
+        "    if well_name not in wells_used:\n",
+        "        raise ValueError(\"Unknown well name\")\n",
+        "    idx = wells_used.index(well_name)\n",
+        "    t_axis = np.arange(T_total)\n",
+        "\n",
+        "    plt.figure(figsize=(8, 4))\n",
+        "    y_true = Y_full[idx]\n",
+        "    plt.plot(t_axis[:T_pref], y_true[:T_pref], label=\"observed prefix\", linewidth=2)\n",
+        "    if np.isfinite(y_true[T_pref:]).any():\n",
+        "        plt.plot(t_axis[T_pref:], y_true[T_pref:], label=\"true suffix\", alpha=0.6)\n",
+        "    plt.plot(t_axis[T_pref:], Y_pred_knn[idx], label=\"knn forecast\", linewidth=2)\n",
+        "    plt.axvline(T_pref - 1, color=\"gray\", linestyle=\"--\", linewidth=1)\n",
+        "    plt.title(f\"Well: {well_name}\")\n",
+        "    plt.xlabel(\"month index\")\n",
+        "    plt.ylabel(\"oil rate\")\n",
+        "    plt.legend()\n",
+        "    plt.grid(True, alpha=0.2)\n",
+        "    plt.show()\n",
+        "\n",
+        "# пример: посмотрим на первую прогнозную скважину (при наличии)\n",
+        "if forecast_wells:\n",
+        "    plot_forecast(forecast_wells[0])"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "if forecast_indices:\n",
+        "    idx = forecast_indices[0]\n",
+        "    well_name = wells_used[idx]\n",
+        "    print(f\"Cluster vote for {well_name}:\")\n",
+        "    print(vote_details.get(idx, {}))\n",
+        "    print(\"\n",
+        "Neighbors used in forecast:\")\n",
+        "    print(knn_info[\"neighbors\"].get(idx, {}))"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a new notebook that walks through reference-only manifold building, cluster voting for prefix-only wells, and cluster-constrained forecasting
- extend `tools/forecast.py` with a `vote_cluster_by_prefix` helper and enhance `knn_forecast` to support custom neighbour pools for cluster-restricted predictions

## Testing
- python -m compileall tools/forecast.py

------
https://chatgpt.com/codex/tasks/task_e_68c91903a9a0832eada1db8cb9f28add